### PR TITLE
Set panic = "abort" also on non-webR build

### DIFF
--- a/src/Makevars.webr
+++ b/src/Makevars.webr
@@ -10,7 +10,7 @@ all: C_clean
 $(SHLIB): $(STATLIB)
 
 $(STATLIB):
-	CARGO_PROFILE_RELEASE_PANIC="abort" PATH="$(PATH):$(HOME)/.cargo/bin" \
+	PATH="$(PATH):$(HOME)/.cargo/bin" \
 		cargo +nightly build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) \
 		--target $(TARGET) -Zbuild-std=panic_abort,std
 	exit

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -11,3 +11,6 @@ savvy = { git = "https://github.com/yutannihilation/savvy" }
 savvy-ffi = { git = "https://github.com/yutannihilation/savvy" }
 
 [workspace]
+
+[profile.release]
+panic = "abort"


### PR DESCRIPTION
Since the savvy framework doesn't rely on panic, let's give up recovering from panic and reduce the binary size.