### PR TITLE
Let pak do the heavy lifting

### DIFF
--- a/.github/workflows/deploy-cran-repo.yml
+++ b/.github/workflows/deploy-cran-repo.yml
@@ -15,19 +15,12 @@ jobs:
       - name: Checkout calling repository
         uses: actions/checkout@v4
 
-      - name: Checkout prqlr repository
-        uses: actions/checkout@v4
-        with:
-          repository: yutannihilation/prqlr
-          ref: savvy
-          path: prqlr
-
       - name: Build wasm packages
         uses: yutannihilation/r-wasm-actions/build-rwasm@main
         with:
           packages: |
             local::savvyExamples
-            local::prqlr
+            github::yutannihilation/prqlr@savvy
 
       - name: Check size
         run: |


### PR DESCRIPTION
Avoids using another action to check out the modified `prqlr` repository in favor of modifying the `packages` key and delegating the work to `pak`

```default
github::yutannihilation/prqlr@savvy
```

https://pak.r-lib.org/reference/pak_package_sources.html#github-packages-github-

